### PR TITLE
Fix single node cluster not starting

### DIFF
--- a/k8s-scratch.sh
+++ b/k8s-scratch.sh
@@ -230,13 +230,21 @@ systemctl restart docker
 ## https://kubernetes.io/docs/setup/scratch/#kubelet
 
 echo ">>> Configuring systemd service for kubelet..."
+# TODO: Update k8s.io scratch documentation
+#   - Disambiguate "Otherwise" bullet-point
+# TODO: Look into using Kubelet config file
+#   Flag --pod-manifest-path has been deprecated,
+#   This parameter should be set via the config file
+#   specified by the Kubelet's --config flag.
+#   See https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/
+#   for more information.
 cat > /etc/systemd/system/kubelet.service <<EOF
 [Unit]
 Description=kubelet: The Kubernetes Node Agent
 Documentation=http://kubernetes.io/docs/
 
 [Service]
-ExecStart=/usr/local/bin/kubelet --kubeconfig="${KUBELET_CONFIG}"
+ExecStart=/usr/local/bin/kubelet --kubeconfig="${KUBELET_CONFIG}" --pod-manifest-path=/etc/kubernetes/manifests
 Restart=always
 StartLimitInterval=0
 RestartSec=10

--- a/k8s-scratch.sh
+++ b/k8s-scratch.sh
@@ -195,6 +195,11 @@ echo ">>> Enabling swap limit capabilities (effective at next reboot)..."
 sed -i -E 's/^(GRUB_CMDLINE_LINUX=).*/\1"cgroup_enable=memory swapaccount=1"/' /etc/default/grub
 update-grub
 
+if id vagrant >/dev/null 2>&1; then
+  echo '>>> Adding vagrant user to the docker group...'
+  usermod vagrant -g docker
+fi
+
 ### https://wiki.debian.org/BridgeNetworkConnections
 echo ">>> Installing bridge-utils..."
 apt-get install -y bridge-utils

--- a/k8s-scratch.sh
+++ b/k8s-scratch.sh
@@ -131,7 +131,9 @@ openssl x509 -req -in "${CLI_CSR}" -CA "${CA_CERT}" -CAkey "${CA_KEY}" \
   -CAcreateserial -out "${CLI_CERT}" -days 365 -sha256
 
 ### https://kubernetes.io/docs/setup/scratch/#preparing-credentials
-TOKENS_FILE="/var/lib/kube-apiserver/known_tokens.csv"
+# TODO: Update k8s.io scratch documentation
+#   - Make tokens file path conherent across the doc
+TOKENS_FILE="/srv/kubernetes/known_tokens.csv"
 CONTEXT_NAME="k8s-scratch"
 KUBE_PROXY_CONFIG="/var/lib/kube-proxy/kubeconfig"
 KUBELET_CONFIG="/var/lib/kubelet/kubeconfig"
@@ -391,6 +393,10 @@ EOF
   ## https://kubernetes.io/docs/setup/scratch/#apiserver-controller-manager-and-scheduler
 
   echo ">>> Creating apiserver pod manifest..."
+  # TODO: Update k8s.io scratch documentation
+  #   - Remove extra 'e' in "server.cert" => "server.crt" to be consistent with MASTER_CERT
+  #   - Suggest moving the token to /srv/kubernetes for consistency as well
+  #   - Remove `--token-auth-file` not mentioned in the doc
   cat > /etc/kubernetes/manifests/apiserver.manifest <<EOF
 {
   "kind": "Pod",
@@ -411,12 +417,11 @@ EOF
           "--address=127.0.0.1",
           "--service-cluster-ip-range=${SERVICE_CLUSTER_IP_RANGE}",
           "--etcd-servers=http://127.0.0.1:2379",
-          "--tls-cert-file=/srv/kubernetes/server.cert",
+          "--tls-cert-file=/srv/kubernetes/server.crt",
           "--tls-private-key-file=/srv/kubernetes/server.key",
           "--enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,Priority,ResourceQuota",
           "--client-ca-file=/srv/kubernetes/ca.crt",
-          "--token-auth-file=/srv/kubernetes/known_tokens.csv",
-          "--basic-auth-file=/srv/kubernetes/basic_auth.csv"
+          "--token-auth-file=/srv/kubernetes/known_tokens.csv"
         ],
         "ports": [
           {

--- a/k8s-scratch.sh
+++ b/k8s-scratch.sh
@@ -50,7 +50,7 @@ for bin in kubectl kube-proxy kubelet; do
 done
 
 ### https://kubernetes.io/docs/setup/scratch/#selecting-images
-ETCD_VERSION='v3.2.24'
+ETCD_VERSION='3.2.24'
 TAG="${K8S_VERSION}"
 HYPERKUBE_IMAGE="k8s.gcr.io/hyperkube:${TAG}"
 ETCD_IMAGE="k8s.gcr.io/etcd:${ETCD_VERSION}"
@@ -317,7 +317,8 @@ if [[ "${NODE_ID}" -eq 1 ]]; then
         "resources": {},
         "command": [
           "etcd",
-          "--name etcd-scratch",
+          "--name",
+          "etcd-scratch",
           "--listen-peer-urls=http://127.0.0.1:2380",
           "--initial-advertise-peer-urls=http://127.0.0.1:2380",
           "--advertise-client-urls=http://127.0.0.1:2379",


### PR DESCRIPTION
* Indeed, Kubelet obviously needs to know where are the manifests with an argument (the "otherwise" bullet-point confused me, I might want to look into the other arguments)
* `kube-apiserver` and `etcd` manifests had errors
* Bonus: Allow vagrant user to use docker